### PR TITLE
Update badge link from to itself to npmjs.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Locally view markdown files in a browser.
 
-![NPM version](https://badge.fury.io/js/md-fileserver.svg)
+[![NPM version](https://badge.fury.io/js/md-fileserver.svg)](https://www.npmjs.com/package/md-fileserver)
 
 Starts a local server to render "markdown" files within your browser:
 


### PR DESCRIPTION
By default the image has a link to open the image
itself in a browser window. Update it to instead
link to the package information on npmjs.org.